### PR TITLE
Add missing LinkedIn link to about page

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -60,6 +60,7 @@
 <ul>
 <li>Email: <a href="mailto:ashley.ruglys@gmail.com">ashley.ruglys@gmail.com</a></li>
 <li>GitHub: <a href="https://github.com/expenses">expenses</a></li>
+<li><a href="https://www.linkedin.com/in/ashley-ruglys/">LinkedIn</a></li>
 </ul>
 
 </div>


### PR DESCRIPTION
Current `index.html`:

![スクリーンショット 2021-12-01 11 28 42](https://user-images.githubusercontent.com/15306309/144252634-1f3bc19b-43bc-4bc1-8728-03e473da35de.png)

Current `about/index.html`:

![スクリーンショット 2021-12-01 11 28 51](https://user-images.githubusercontent.com/15306309/144252659-4086f8c9-4120-4f90-aefa-32cf744310e5.png)
